### PR TITLE
Fix request body log

### DIFF
--- a/AspNetSerilog/Extractors/HttpContextExtractor.cs
+++ b/AspNetSerilog/Extractors/HttpContextExtractor.cs
@@ -186,6 +186,12 @@ namespace AspNetSerilog.Extractors
                 return null;
             }
 
+            try
+            {
+                context.Request.Body.Position = 0;
+            }
+            catch (Exception) { }
+
             string body = null;
             using (StreamReader reader = new StreamReader(context.Request.Body))
             {


### PR DESCRIPTION
### Status

READY

### Whats?

Request body was not being logged in some cases. The stream position of the context.request.body was not being setted to 0 before being read. I just start to set to zero