### PR TITLE
:sparkles: Adds HttpContext masking

### DIFF
--- a/AspNetSerilog.sln
+++ b/AspNetSerilog.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "devops", "devops", "{0D6BB4
 		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetSerilogTests", "AspNetSerilogTests\AspNetSerilogTests.csproj", "{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,10 @@ Global
 		{816905D7-8F1A-4D87-8C82-789DE36467A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{816905D7-8F1A-4D87-8C82-789DE36467A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{816905D7-8F1A-4D87-8C82-789DE36467A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AspNetSerilog/CommunicationLogger.cs
+++ b/AspNetSerilog/CommunicationLogger.cs
@@ -94,10 +94,10 @@ namespace AspNetSerilog
 
             LogContext.PushProperty("RequestBody", context.GetRequestBody(this.SerilogConfiguration.BlacklistRequest));
             LogContext.PushProperty("Method", context.Request.Method);
-            LogContext.PushProperty("Path", context.Request.Path);
+            LogContext.PushProperty("Path", context.GetPath(this.SerilogConfiguration.HttpContextBlacklist));
             LogContext.PushProperty("Host", context.GetHost());
             LogContext.PushProperty("Port", context.GetPort());
-            LogContext.PushProperty("Url", context.GetFullUrl(this.SerilogConfiguration.QueryStringBlacklist));
+            LogContext.PushProperty("Url", context.GetFullUrl(this.SerilogConfiguration.QueryStringBlacklist, this.SerilogConfiguration.HttpContextBlacklist));
             LogContext.PushProperty("QueryString", context.GetRawQueryString(this.SerilogConfiguration.QueryStringBlacklist));
             LogContext.PushProperty("Query", context.GetQueryString(this.SerilogConfiguration.QueryStringBlacklist));
             LogContext.PushProperty("RequestHeaders", context.GetRequestHeaders(this.SerilogConfiguration.HeaderBlacklist));

--- a/AspNetSerilog/Extractors/HttpContextExtractor.cs
+++ b/AspNetSerilog/Extractors/HttpContextExtractor.cs
@@ -293,19 +293,53 @@ namespace AspNetSerilog.Extractors
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public static object GetFullUrl(this HttpContext context, string[] blacklist)
+        public static object GetFullUrl(this HttpContext context, string[] queryBlacklist, string[] httpContextBlackList)
         {
             var absoluteUri = string.Concat(
                        context?.Request?.Scheme,
                        "://",
                        context?.Request?.Host.ToUriComponent(),
-                       context?.Request?.PathBase.ToUriComponent(),
-                       context?.Request?.Path.ToUriComponent(),
-                       context.GetRawQueryString(blacklist));
+                       context?.GetPathBase(httpContextBlackList),
+                       context?.GetPath(httpContextBlackList),
+                       context.GetRawQueryString(queryBlacklist));
 
             return absoluteUri;
         }
 
+        /// <summary>
+        /// Get Path
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static object GetPath(this HttpContext context, string[] blacklist)
+        {
+            
+            if (blacklist?.Any() == true && blacklist.Contains("Path"))
+            {
+                return @"/******";
+            }
+
+            return context.Request.Path.ToUriComponent();
+            
+        }
+        
+        /// <summary>
+        /// Get PathBase
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static object GetPathBase(this HttpContext context, string[] blacklist)
+        {
+            
+            if (blacklist?.Any() == true && blacklist.Contains("PathBase"))
+            {
+                return @"/******";
+            }
+
+            return context.Request.PathBase.ToUriComponent();
+            
+        }
+        
         /// <summary>
         /// Get response content
         /// </summary>

--- a/AspNetSerilog/SerilogConfiguration.cs
+++ b/AspNetSerilog/SerilogConfiguration.cs
@@ -12,6 +12,8 @@ namespace AspNetSerilog
         public string[] HeaderBlacklist { get; set; }
 
         public string[] QueryStringBlacklist { get; set; }
+        
+        public string[] HttpContextBlacklist { get; set; }
 
         public string InformationTitle { get; set; }
 

--- a/AspNetSerilogTests/AspNetSerilogTests.csproj
+++ b/AspNetSerilogTests/AspNetSerilogTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="HttpContextMoq" Version="1.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.0.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\AspNetSerilog\AspNetSerilog.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/AspNetSerilogTests/Extractors/HttpContextExtractorTest.cs
+++ b/AspNetSerilogTests/Extractors/HttpContextExtractorTest.cs
@@ -1,0 +1,131 @@
+using AspNetSerilog.Extractors;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace AspNetSerilogTests.Extractors
+{
+    public class HttpContextExtractorTest
+    {
+        private HttpContext _httpContext;
+
+        public HttpContextExtractorTest()
+        {
+            _httpContext = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public void GetPath_InformingThePathInTheBlackList_ReturnsMaskedPath()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Path = new PathString("/foo/bar");
+
+            var blackList = new[] {"Path"};
+
+            var expected = "/******";
+            var actual = HttpContextExtractor.GetPath(_httpContext, blackList);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetPath_NotInformingThePathInTheBlackList_ReturnsTheValueGivenInThePath()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Path = new PathString("/foo/bar");
+
+            var blackList = new string[] { };
+
+            var expected = "/foo/bar";
+            var actual = HttpContextExtractor.GetPath(_httpContext, blackList);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetPathBase_InformingThePathBaseInTheBlackList_ReturnsMaskedPath()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Path = new PathString("/foo/bar");
+            _httpContext.Request.PathBase = new PathString("/sample-alias/");
+
+            var blackList = new[] {"PathBase"};
+
+            var expected = "/******";
+            var actual = HttpContextExtractor.GetPathBase(_httpContext, blackList);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetPathBase_NotInformingThePathBaseInTheBlackList_ReturnsTheValueGivenInThePathBase()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Path = new PathString("/foo/bar");
+            _httpContext.Request.PathBase = new PathString("/sample-alias/");
+
+            var blackList = new string[] { };
+
+            var expected = "/sample-alias/";
+            var actual = HttpContextExtractor.GetPathBase(_httpContext, blackList);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetFullUrl_InformingThePathInTheBlackList_ReturnsMaskedPath()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Scheme = "http";
+            _httpContext.Request.Host = new HostString("localhost:80");
+            _httpContext.Request.PathBase = new PathString("/sample-alias");
+            _httpContext.Request.Path = new PathString("/foo/bar");
+
+            string[] queryBlackList = {};
+            var httpContextBlackList = new[] {"Path"};
+
+            var expected = "http://localhost:80/sample-alias/******?";
+            
+            var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
+
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void GetFullUrl_InformingThePathBaseInTheBlackList_ReturnsMaskedPath()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Scheme = "http";
+            _httpContext.Request.Host = new HostString("localhost:80");
+            _httpContext.Request.PathBase = new PathString("/sample-alias");
+            _httpContext.Request.Path = new PathString("/foo/bar");
+
+            string[] queryBlackList = {};
+            var httpContextBlackList = new[] {"PathBase"};
+
+            var expected = "http://localhost:80/******/foo/bar?";
+            
+            var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
+
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void GetFullUrl_InformingThePathAndPathBaseInTheBlackList_ReturnsMaskedPath()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Scheme = "http";
+            _httpContext.Request.Host = new HostString("localhost:80");
+            _httpContext.Request.PathBase = new PathString("/sample-alias");
+            _httpContext.Request.Path = new PathString("/foo/bar");
+
+            string[] queryBlackList = {};
+            var httpContextBlackList = new[] {"PathBase", "Path"};
+
+            var expected = "http://localhost:80/******/******?";
+            
+            var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Whats?
Implements a way to mask fields in the HttpContext.

Why?
Because it is needed to mask some fields when logging information present in http context.

How?
Added new methods to handle the field masking.
Added fields in the configuration file to store and separate the fields that we need to mask.