### PR TITLE
[feature] Add partial masking feature

### DIFF
--- a/AspNetSerilog.sln
+++ b/AspNetSerilog.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30011.22
@@ -27,7 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "devops", "devops", "{0D6BB4
 		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetSerilogTests", "AspNetSerilogTests\AspNetSerilogTests.csproj", "{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetSerilogTests", "AspNetSerilogTests\AspNetSerilogTests.csproj", "{9374A8D1-F652-4C32-9266-E7EDE2CA7B56}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/AspNetSerilog/AspNetSerilog.csproj
+++ b/AspNetSerilog/AspNetSerilog.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonMasking" Version="1.2.0" />
+    <PackageReference Include="JsonMasking" Version="1.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/AspNetSerilog/CommunicationLogger.cs
+++ b/AspNetSerilog/CommunicationLogger.cs
@@ -92,7 +92,7 @@ namespace AspNetSerilog
                 exceptionStackTrace = HandleFieldSize(exception.StackTrace, ExceptionMaxLenghtExtension.ErrorExceptionLenght);
             }
 
-            LogContext.PushProperty("RequestBody", context.GetRequestBody(this.SerilogConfiguration.BlacklistRequest));
+            LogContext.PushProperty("RequestBody", context.GetRequestBody(this.SerilogConfiguration.BlacklistRequest, this.SerilogConfiguration.BlacklistRequestPartial));
             LogContext.PushProperty("Method", context.Request.Method);
             LogContext.PushProperty("Path", context.GetPath(this.SerilogConfiguration.HttpContextBlacklist));
             LogContext.PushProperty("Host", context.GetHost());
@@ -112,7 +112,7 @@ namespace AspNetSerilog
             LogContext.PushProperty("Operation", action?.ToString()); 
             LogContext.PushProperty("ErrorException", exceptionStackTrace);
             LogContext.PushProperty("ErrorMessage", exceptionMessage);
-            LogContext.PushProperty("ResponseContent", context.GetResponseContent(this.SerilogConfiguration.BlacklistResponse));
+            LogContext.PushProperty("ResponseContent", context.GetResponseContent(this.SerilogConfiguration.BlacklistResponse, this.SerilogConfiguration.BlacklistResponsePartial));
             LogContext.PushProperty("ContentType", context.Response.ContentType);
             LogContext.PushProperty("ContentLength", context.GetResponseLength());
             LogContext.PushProperty("ResponseHeaders", context.GetResponseHeaders(this.SerilogConfiguration.HeaderBlacklist));

--- a/AspNetSerilog/Extractors/HttpContextExtractor.cs
+++ b/AspNetSerilog/Extractors/HttpContextExtractor.cs
@@ -406,8 +406,7 @@ namespace AspNetSerilog.Extractors
             {
                 if (maskJson == true && backlist?.Any() == true)
                 {
-                    //content = content.MaskFields(backlist, "******", blacklistPartial); // TODO: Modificar após subir a nova versão estavel do JsonMasking e atualizar
-                    content = content.MaskFields(backlist, "******");
+                    content = content.MaskFields(backlist, "******", blacklistPartial);
                 }
 
                 return content.DeserializeAsObject();

--- a/AspNetSerilog/SerilogConfiguration.cs
+++ b/AspNetSerilog/SerilogConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using Serilog;
+using System;
 using System.Collections.Generic;
 
 namespace AspNetSerilog
@@ -7,7 +8,11 @@ namespace AspNetSerilog
     {
         public string[] BlacklistRequest { get; set; }
 
+        public Dictionary<string, Func<string, string>> BlacklistRequestPartial { get; set; }
+
         public string[] BlacklistResponse { get; set; }
+
+        public Dictionary<string, Func<string, string>> BlacklistResponsePartial { get; set; }
 
         public string[] HeaderBlacklist { get; set; }
 

--- a/AspNetSerilogTests/AspNetSerilogTests.csproj
+++ b/AspNetSerilogTests/AspNetSerilogTests.csproj
@@ -1,27 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="HttpContextMoq" Version="1.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\AspNetSerilog\AspNetSerilog.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="HttpContextMoq" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AspNetSerilog\AspNetSerilog.csproj" />
+  </ItemGroup>
 </Project>

--- a/AspNetSerilogTests/Extractors/HttpContextExtractorTest.cs
+++ b/AspNetSerilogTests/Extractors/HttpContextExtractorTest.cs
@@ -10,7 +10,7 @@ namespace AspNetSerilogTests.Extractors
 {
     public class HttpContextExtractorTest
     {
-        private readonly HttpContext _httpContext;
+        private HttpContext _httpContext;
 
         public HttpContextExtractorTest()
         {
@@ -20,115 +20,136 @@ namespace AspNetSerilogTests.Extractors
         [Fact]
         public void GetPath_InformingThePathInTheBlackList_ReturnsMaskedPath()
         {
+            // Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Path = new PathString("/foo/bar");
 
-            var blackList = new[] {"Path"};
-
+            var blackList = new[] { "Path" };
             var expected = "/******";
+
+            // Act
             var actual = HttpContextExtractor.GetPath(_httpContext, blackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void GetPath_NotInformingThePathInTheBlackList_ReturnsTheValueGivenInThePath()
         {
+            // Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Path = new PathString("/foo/bar");
 
             var blackList = new string[] { };
-
             var expected = "/foo/bar";
+
+            // Act
             var actual = HttpContextExtractor.GetPath(_httpContext, blackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void GetPathBase_InformingThePathBaseInTheBlackList_ReturnsMaskedPath()
         {
+            // Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Path = new PathString("/foo/bar");
             _httpContext.Request.PathBase = new PathString("/sample-alias/");
 
-            var blackList = new[] {"PathBase"};
-
+            var blackList = new[] { "PathBase" };
             var expected = "/******";
+
+            //Act
             var actual = HttpContextExtractor.GetPathBase(_httpContext, blackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void GetPathBase_NotInformingThePathBaseInTheBlackList_ReturnsTheValueGivenInThePathBase()
         {
+            // Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Path = new PathString("/foo/bar");
             _httpContext.Request.PathBase = new PathString("/sample-alias/");
 
             var blackList = new string[] { };
-
             var expected = "/sample-alias/";
+
+            // Act
             var actual = HttpContextExtractor.GetPathBase(_httpContext, blackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void GetFullUrl_InformingThePathInTheBlackList_ReturnsMaskedPath()
         {
+            // Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Scheme = "http";
             _httpContext.Request.Host = new HostString("localhost:80");
             _httpContext.Request.PathBase = new PathString("/sample-alias");
             _httpContext.Request.Path = new PathString("/foo/bar");
 
-            string[] queryBlackList = {};
-            var httpContextBlackList = new[] {"Path"};
+            string[] queryBlackList = { };
+            var httpContextBlackList = new[] { "Path" };
 
             var expected = "http://localhost:80/sample-alias/******?";
-            
+
+            // Act
             var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
-        
+
         [Fact]
         public void GetFullUrl_InformingThePathBaseInTheBlackList_ReturnsMaskedPath()
         {
+            // Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Scheme = "http";
             _httpContext.Request.Host = new HostString("localhost:80");
             _httpContext.Request.PathBase = new PathString("/sample-alias");
             _httpContext.Request.Path = new PathString("/foo/bar");
 
-            string[] queryBlackList = {};
-            var httpContextBlackList = new[] {"PathBase"};
+            string[] queryBlackList = { };
+            var httpContextBlackList = new[] { "PathBase" };
 
             var expected = "http://localhost:80/******/foo/bar?";
-            
+
+            // Act
             var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
-        
+
         [Fact]
         public void GetFullUrl_InformingThePathAndPathBaseInTheBlackList_ReturnsMaskedPath()
         {
+            //Arrange
             _httpContext.Request.Method = "GET";
             _httpContext.Request.Scheme = "http";
             _httpContext.Request.Host = new HostString("localhost:80");
             _httpContext.Request.PathBase = new PathString("/sample-alias");
             _httpContext.Request.Path = new PathString("/foo/bar");
 
-            string[] queryBlackList = {};
-            var httpContextBlackList = new[] {"PathBase", "Path"};
+            string[] queryBlackList = { };
+            var httpContextBlackList = new[] { "PathBase", "Path" };
 
             var expected = "http://localhost:80/******/******?";
-            
+
+            // Act
             var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
 
@@ -228,10 +249,10 @@ namespace AspNetSerilogTests.Extractors
             string[] queryBlackList = { "*card.number", "*password" };
 
             // Act
-            var valueUnmodified = _httpContext.GetRequestBody(queryBlackList, blacklistPartialWithInvalidFuncMock);
+            var value = _httpContext.GetRequestBody(queryBlackList, blacklistPartialWithInvalidFuncMock);
 
             // assert
-            Assert.Equal(EXPECTED_VALUE, valueUnmodified);
+            Assert.Equal(EXPECTED_VALUE, value);
         }
     }
 }

--- a/AspNetSerilogTests/Extractors/HttpContextExtractorTest.cs
+++ b/AspNetSerilogTests/Extractors/HttpContextExtractorTest.cs
@@ -1,16 +1,20 @@
 using AspNetSerilog.Extractors;
+using AspNetSerilogTests.Mocks;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace AspNetSerilogTests.Extractors
 {
     public class HttpContextExtractorTest
     {
-        private HttpContext _httpContext;
+        private readonly HttpContext _httpContext;
 
         public HttpContextExtractorTest()
         {
-            _httpContext = new DefaultHttpContext();
+            _httpContext = HttpContextMock.DefaultHttpContext();
         }
 
         [Fact]
@@ -126,6 +130,108 @@ namespace AspNetSerilogTests.Extractors
             var actual = HttpContextExtractor.GetFullUrl(_httpContext, queryBlackList, httpContextBlackList);
 
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetContentAsObjectByContentTypeJson_WithFilledBlacklist_ReturnsMaskedBody()
+        {
+            // Arrange
+            const string EXPECTED_VALUE = "{\"Test\":\"1\",\"Card\":{\"Number\":\"******\",\"Password\":\"******\",\"Email\":\"email@test.com\",\"Card\":{\"Number\":\"******\",\"Password\":\"******\"},\"Teste\":{\"Card\":{\"Number\":\"******\",\"Password\":\"******\",\"Email\":\"email@test.com\"}}}}";
+
+            string[] queryBlackList = { "*card.number", "*password" };
+
+            // Act
+            var value = _httpContext.GetRequestBody(queryBlackList);
+
+            // Assert
+            Assert.Equal(EXPECTED_VALUE, JsonConvert.SerializeObject(value));
+        }
+
+        [Fact]
+        public void GetContentAsObjectByContentTypeJson_WithEmptyBlacklist_ReturnsBodyWithoutMask()
+        {
+            // Arrange
+            const string EXPECTED_VALUE = "{\"Test\":\"1\",\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\",\"Email\":\"email@test.com\",\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\"},\"Teste\":{\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\",\"Email\":\"email@test.com\"}}}}";
+
+            string[] queryBlackList = { };
+
+            // Act
+            var value = _httpContext.GetRequestBody(queryBlackList);
+
+            // Assert
+            Assert.Equal(EXPECTED_VALUE, JsonConvert.SerializeObject(value));
+        }
+
+        [Fact]
+        public void GetContentAsObjectByContentTypeJson_WithBlacklistAndPartialBlacklist_ReturnsBodyMaskedAndPartialMasked()
+        {
+            // Arrange
+            const string EXPECTED_VALUE = "{\"Test\":\"1\",\"Card\":{\"Number\":\"462294*****9865\",\"Password\":\"******\",\"Email\":\"email@test.com\",\"Card\":{\"Number\":\"462294*****9865\",\"Password\":\"******\"},\"Teste\":{\"Card\":{\"Number\":\"462294*****9865\",\"Password\":\"******\",\"Email\":\"email@test.com\"}}}}";
+
+            var blacklistPartialMock = BlacklistPartialMock.DefaultBlackListPartial;
+
+            string[] queryBlackList = { "*card.number", "*password" };
+
+            // Act
+            var value = _httpContext.GetRequestBody(queryBlackList, blacklistPartialMock);
+
+            // Assert
+            Assert.Equal(EXPECTED_VALUE, JsonConvert.SerializeObject(value));
+        }
+
+        [Fact]
+        public void GetContentAsObjectByContentTypeJson_WithEmptyBlacklistAndFilledPartialBlacklist_ReturnsBodyWithoutMask()
+        {
+            // Arrange
+            const string EXPECTED_VALUE = "{\"Test\":\"1\",\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\",\"Email\":\"email@test.com\",\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\"},\"Teste\":{\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\",\"Email\":\"email@test.com\"}}}}";
+
+            var blacklistPartialMock = BlacklistPartialMock.DefaultBlackListPartial;
+
+            string[] queryBlackList = { };
+
+            // Act
+            var value = _httpContext.GetRequestBody(queryBlackList, blacklistPartialMock);
+
+            // Assert
+            Assert.Equal(EXPECTED_VALUE, JsonConvert.SerializeObject(value));
+        }
+
+        [Fact]
+        public void GetContentAsObjectByContentTypeJson_WithFilledBlacklistAndEmptyPartialBlacklist_ReturnsBodyWithTotalMask()
+        {
+            // Arrange
+            const string EXPECTED_VALUE = "{\"Test\":\"1\",\"Card\":{\"Number\":\"******\",\"Password\":\"******\",\"Email\":\"email@test.com\",\"Card\":{\"Number\":\"******\",\"Password\":\"******\"},\"Teste\":{\"Card\":{\"Number\":\"******\",\"Password\":\"******\",\"Email\":\"email@test.com\"}}}}";
+
+            var blacklistPartialMock = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase) { };
+
+            string[] queryBlackList = { "*card.number", "*password" };
+
+            // Act
+            var value = _httpContext.GetRequestBody(queryBlackList, blacklistPartialMock);
+
+            // Assert
+            Assert.Equal(EXPECTED_VALUE, JsonConvert.SerializeObject(value));
+        }
+
+        [Fact]
+        public void GetContentAsObjectByContentTypeJson_WithInvalidFunctionInDictionaryOfPartialBlacklist_ShouldAbortJsonMaskingAndReturnValueUnmodified()
+        {
+            // Arrange
+            const string EXPECTED_VALUE = "{\"Test\":\"1\",\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\",\"Email\":\"email@test.com\",\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\"},\"Teste\":{\"Card\":{\"Number\":\"4622943127049865\",\"Password\":\"somepass#here2\",\"Email\":\"email@test.com\"}}}}";
+            const int INDEX_OUT_OF_RANGE = 100;
+
+            var blacklistPartialWithInvalidFuncMock = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                {"*card.number", value => value[INDEX_OUT_OF_RANGE..] }
+            };
+
+            string[] queryBlackList = { "*card.number", "*password" };
+
+            // Act
+            var valueUnmodified = _httpContext.GetRequestBody(queryBlackList, blacklistPartialWithInvalidFuncMock);
+
+            // assert
+            Assert.Equal(EXPECTED_VALUE, valueUnmodified);
         }
     }
 }

--- a/AspNetSerilogTests/Mocks/BlacklistPartialMock.cs
+++ b/AspNetSerilogTests/Mocks/BlacklistPartialMock.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace AspNetSerilogTests.Mocks
+{
+    public static class BlacklistPartialMock
+    {
+        private const string CARD_NUMBER_PATTERN = @"(\d{4,5})[ -|]?(\d{3,6})[ -|]?(\d{3,5})[ -|]?(\d{3,4})";
+
+        private const string EMPTY_SPACE_PATTERN = @"\s+";
+
+        public static Dictionary<string, Func<string, string>> DefaultBlackListPartial = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            {"*card.number", MaskCardNumber }
+        };
+
+        public static string MaskCardNumber(this string text)
+        {
+            const int MINIMAL_LENGTH = 10;
+
+            text = Regex.Replace(text, EMPTY_SPACE_PATTERN, "");
+
+            if (string.IsNullOrEmpty(text) || text.Length < MINIMAL_LENGTH || !ContainsCardNumber(text))
+            {
+                return text;
+            }
+
+            var firstSix = text[..6];
+            var lastFour = text[^4..];
+            if (firstSix.Length == 6 && lastFour.Length == 4)
+            {
+                return $"{firstSix}*****{lastFour}";
+            }
+
+            return text;
+        }
+
+        public static bool ContainsCardNumber(this string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return false;
+
+            return Regex.IsMatch(text, CARD_NUMBER_PATTERN);
+        }
+    }
+}

--- a/AspNetSerilogTests/Mocks/HttpContextMock.cs
+++ b/AspNetSerilogTests/Mocks/HttpContextMock.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+namespace AspNetSerilogTests.Mocks
+{
+    public static class HttpContextMock
+    {
+        public static DefaultHttpContext DefaultHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+
+            var requestBody = new
+            {
+                Test = "1",
+                Card = new
+                {
+                    Number = "4622943127049865",
+                    Password = "somepass#here2",
+                    Email = "email@test.com",
+                    Card = new
+                    {
+                        Number = "4622943127049865",
+                        Password = "somepass#here2"
+                    },
+                    Teste = new
+                    {
+                        Card = new
+                        {
+                            Number = "4622943127049865",
+                            Password = "somepass#here2",
+                            Email = "email@test.com"
+                        }
+                    }
+                }
+            };
+
+            string jsonString = JsonConvert.SerializeObject(requestBody);
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonString);
+            var stream = new MemoryStream(byteArray);
+            httpContext.Request.Body = stream;
+
+            httpContext.Request.Headers.Add("Content-Type", "json");
+
+            return httpContext;
+        }
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,7 +184,10 @@ stages:
       condition: eq(variables['execute_test'], 'true')
       inputs:
         artifact: UnitTestResults
-    - task: SonarCloudPrepare@1
+    - script: |
+        sudo apt-get install unzip
+      displayName: Install sonarqube dependency package
+    - task: SonarCloudPrepare@2
       displayName: Start Sonarqube Analysis
       inputs:
         SonarCloud: '$(sonarcloud_account)'
@@ -192,6 +195,8 @@ stages:
         scannerMode: 'MSBuild'
         projectKey: '$(sonarcloud_project)'
         projectName: '$(sdk_project_name)'
+        cliProjectKey: '$(sonarcloud_project)'
+        cliProjectName: '$(sdk_project_name)'
         extraProperties: |
           sonar.sourceEncoding=UTF-8
           sonar.scm.forceReloadAll=true
@@ -200,9 +205,9 @@ stages:
     - script: |
         dotnet build "$(solution_path)"
       displayName: Runnig Build For Analysis
-    - task: SonarCloudAnalyze@1
+    - task: SonarCloudAnalyze@2
       displayName: Finish Sonarqube Analysis
-    - task: SonarCloudPublish@1
+    - task: SonarCloudPublish@2
       displayName: Publish Sonarqube Analysis
       inputs:
         pollingTimeoutSec: '300'


### PR DESCRIPTION
![the-s-impsons-bush](https://github.com/ThiagoBarradas/aspnet-serilog/assets/92134670/516a057c-91ea-4d6d-a3e2-6b21398ff258)

### Status

READY

### Whats?

Add the option for a new blacklist where some properties do not need to be fully masked anymore. New rules can be applied to them for partial masking.

### Why?

We need a way to display the card BINs, and the option to apply a custom partial mask would solve this problem.

### How?

Add a new parameter to both the methods that handle the request and the response, and both are optional. This parameter is a dictionary where the key is the property to be masked and the value is a function that applies a specific masking rule to that property. All these additional parameters are optional, ensuring that if an existing integration updates to this new version without changing anything in the implementation, it will have no impact.

Addition of unit tests that validate these methods handling the masking. These tests did not exist before.
An upgrade to .NET in the test project, as the tests were no longer working because they were aborted, indicating that an upgrade to the .NET version was necessary.

### Attachments (if appropriate)

- Continue fully masking if the partial mask is not provided.
![image](https://github.com/ThiagoBarradas/aspnet-serilog/assets/92134670/9a1a06f9-0a0c-4e7b-be29-eb8411de54b3)

- Partially mask if the partial blacklist is provided.
![image](https://github.com/ThiagoBarradas/aspnet-serilog/assets/92134670/45369d09-1242-4c83-be7f-155e48da017f)


### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [X] Implements unit tests
- [ ] Is there appropriate logging included?
- [X] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
